### PR TITLE
fix: improve tuple `Promise.all` typing

### DIFF
--- a/spec/promise_spec.cr
+++ b/spec/promise_spec.cr
@@ -334,7 +334,7 @@ describe Promise do
       result.size.should eq 1
     end
 
-    it "should resolve promises and return an array of values" do
+    it "should resolve promises and return a tuple of values" do
       p1 = Promise.new(Symbol).resolve(:foo)
       p2 = Promise.new(Symbol).resolve(:other)
       val1, val2 = Promise.all(p1, p2).get.not_nil!
@@ -389,11 +389,14 @@ describe Promise do
     end
 
     it "should work with different types" do
-      Promise.all(
+      result = Promise.all(
         Promise.defer { 1.3 },
         Promise.defer { 2 },
         Promise.defer { "string" }
-      ).get.should eq({1.3, 2, "string"})
+      ).get
+
+      typeof(result).should eq(Tuple(Float64, Int32, String))
+      result.should eq({1.3, 2, "string"})
     end
   end
 


### PR DESCRIPTION
With `Promise.all` on a splatted tuple
```cr
result = Promise.all(
  Promise.defer { 1.3 },
  Promise.defer { 2 },
  Promise.defer { "string" }
).get
```
before, `result` would be broadly typed as `Tuple(Float64 | Int32 | String, Float64 | Int32 | String, Float64 | Int32 | String)`, now it would be exactly typed as `Tuple(Float64, Int32, String)`